### PR TITLE
Support for Executable Files

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -15,6 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Run markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@v19
+        with:
+          globs: "**/*.md"
+
       - name: Install dependencies
         run: cargo build
 

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           globs: "**/*.md"
 
-  quality-checks:
+  cargo-quality-checks:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  quality-checks:
+  markdownlint:
     runs-on: ubuntu-latest
 
     steps:
@@ -19,6 +19,12 @@ jobs:
         uses: DavidAnson/markdownlint-cli2-action@v19
         with:
           globs: "**/*.md"
+
+  quality-checks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
 
       - name: Install dependencies
         run: cargo build

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,7 @@
+default: true
+
+# MD013 - Line length
+MD013: false
+
+# MD033 - Inline HTML
+MD033: false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,13 @@
         "Numstat",
         "serde",
         "shellexpand"
-    ]
+    ],
+    "workbench.colorCustomizations": {
+        "commandCenter.border": "#e7e7e799",
+        "titleBar.activeBackground": "#8839ef",
+        "titleBar.activeForeground": "#e7e7e7",
+        "titleBar.inactiveBackground": "#8839ef99",
+        "titleBar.inactiveForeground": "#e7e7e799"
+    },
+    "peacock.color": "#8839ef"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+cargo build                        # build
+cargo build --release              # release build
+cargo test                         # run all tests
+cargo test <test_name>             # run a single test by name
+cargo fmt                          # format code
+cargo fmt -- --check               # check formatting without fixing
+cargo clippy -- -D warnings        # lint (warnings are errors)
+cargo doc --no-deps                # generate docs
+```
+
+CI runs markdownlint on all `.md` files — check `.markdownlint.yaml` for rules.
+
+## Architecture
+
+`dotpatina` is a Rust CLI that manages dotfiles via Handlebars-templated config files. Users define a **Patina** (a TOML file listing template→target file pairs and variables), and the tool either previews (`render`) or writes (`apply`) the rendered output.
+
+**Data flow:**
+
+```text
+CLI args (clap)
+  → PatinaEngine::render_patina() / apply_patina()
+  → Patina::from_toml_file() + load_vars_files()   # loads & merges variables
+  → templating::render_patina()                     # Handlebars rendering (strict, no escaping)
+  → diff generation
+  → user confirmation prompt (apply only)
+  → file writing + permission preservation
+```
+
+**Key modules:**
+
+- [src/cli.rs](src/cli.rs) — `PatinaCli` (clap), `CliPatinaInterface` implementing `PatinaInterface`
+- [src/engine.rs](src/engine.rs) — `PatinaEngine<PI>`, the main orchestrator; generic over `PatinaInterface` so tests can inject a mock UI
+- [src/engine/interface.rs](src/engine/interface.rs) — `PatinaInterface` trait (output, confirm, headers); the abstraction that decouples engine logic from I/O
+- [src/patina.rs](src/patina.rs) — `Patina` struct (TOML deserialization, path resolution, tag filtering)
+- [src/patina/patina_file.rs](src/patina/patina_file.rs) — `PatinaFile` (single template/target pair with optional tags and `preserve_permissions`)
+- [src/patina/vars.rs](src/patina/vars.rs) — variable file loading and merging
+- [src/templating.rs](src/templating.rs) — Handlebars rendering; returns `PatinaFileRender` structs
+- [src/diff.rs](src/diff.rs) — `DiffAnalysis` trait and diff formatting for apply previews
+- [src/utils.rs](src/utils.rs) — `Error` enum, `normalize_path()` (resolves `~` and env vars)
+
+**`PatinaInterface` is the key seam for testing.** Engine tests create a `TestPatinaInterface` that captures output without writing to disk, allowing `render_patina` and `apply_patina` to be tested without side effects.
+
+**Path resolution** (`normalize_path`) expands `~` to the home directory and substitutes `$ENV_VAR` references before canonicalizing — both template and target paths go through this.
+
+## Best Practices
+
+### Automated Testing
+
+After making functional code changes (adding, removing, or modifying existing behavior) make sure to run tests to ensure no functionality has broken.
+If the tests are not consistent with new functionality, update (add, remove, or modify) the tests to account for these changes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "dotpatina"
-version = "1.0.4"
+version = "1.5.0"
 dependencies = [
  "clap",
  "clap-verbosity-flag",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dotpatina"
-version = "1.0.4"
+version = "1.5.0"
 edition = "2021"
 authors = ["Cameron Taylor <axis7818@gmail.com>"]
 description = "dotpatina is a rust application for managing system dotfiles and configuration"

--- a/README.md
+++ b/README.md
@@ -196,7 +196,3 @@ dotpatina apply patina.toml --vars other-vars.toml
 ```
 
 ![gif of updating a patina](./examples/demo/update-patina.gif)
-
-*test rule*
-
-testing breaking a markdown lint rule

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ me.last_name = "Taylor"
 # The template is a handlebar template (or plain file) that is processed.
 # The target is the system location to store the rendered template.
 # Files can also be tagged for filtering when using dotpatina cli commands.
+# Set preserve_permissions = true to copy the template's file permissions to
+# the target — useful for executable scripts.
 
 # ZSH
 [[files]]
@@ -110,6 +112,29 @@ This is useful when variables need to change based on the machine Patinas are be
 ```toml
 me.email = "axis7818@gmail.com"
 ```
+
+### Preserving File Permissions
+
+> **Note:** `preserve_permissions` is only supported on Unix systems.
+
+By default, dotpatina writes target files with standard permissions based on the system umask. When managing executable
+scripts, set `preserve_permissions = true` on a file entry to copy the template's file permissions to the target after
+writing.
+
+```toml
+[[files]]
+template = "scripts/setup.sh"
+target = "~/.local/bin/setup.sh"
+preserve_permissions = true
+```
+
+Make the template executable once, and dotpatina will ensure the target stays executable on every apply:
+
+```sh
+chmod +x scripts/setup.sh
+```
+
+See the full example in [examples/executable-script/](./examples/executable-script/).
 
 ### Template Files
 

--- a/README.md
+++ b/README.md
@@ -196,3 +196,7 @@ dotpatina apply patina.toml --vars other-vars.toml
 ```
 
 ![gif of updating a patina](./examples/demo/update-patina.gif)
+
+*test rule*
+
+testing breaking a markdown lint rule

--- a/examples/executable-script/patina.toml
+++ b/examples/executable-script/patina.toml
@@ -1,0 +1,10 @@
+name = "executable-script"
+description = "Shows how to copy an executable script while preserving its permissions"
+
+[vars]
+greeting = "Hello"
+
+[[files]]
+template = "templates/greet.sh"
+target = "../../output/greet.sh"
+preserve_permissions = true

--- a/examples/executable-script/templates/greet.sh
+++ b/examples/executable-script/templates/greet.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "{{ greeting }} from dotpatina!"

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -134,13 +134,45 @@ where
             let target_file_str = fs::read_to_string(&target_path).unwrap_or_default();
             let diff = TextDiff::from_lines(&target_file_str, &r.render_str);
 
-            r.any_changes = Some(diff.any_changes());
+            let content_changed = diff.any_changes();
+            r.content_changes = Some(content_changed);
+
+            #[cfg(unix)]
+            if r.patina_file.preserve_permissions && target_path.is_file() {
+                use std::os::unix::fs::PermissionsExt;
+                let template_path = patina.get_patina_path(&r.patina_file.template);
+                let template_mode = fs::metadata(&template_path)
+                    .ok()
+                    .map(|m| m.permissions().mode() & 0o7777);
+                let target_mode = fs::metadata(&target_path)
+                    .ok()
+                    .map(|m| m.permissions().mode() & 0o7777);
+                if let (Some(tmpl_mode), Some(tgt_mode)) = (template_mode, target_mode) {
+                    if tmpl_mode != tgt_mode {
+                        r.permission_change = Some((tgt_mode, tmpl_mode));
+                    }
+                }
+            }
+
+            r.any_changes = Some(content_changed || r.permission_change.is_some());
             if r.any_changes.unwrap() {
-                any_changes = true
+                any_changes = true;
             }
 
             if r.any_changes.unwrap() {
-                files_with_changes.push((target_path, diff.to_string()));
+                let mut diff_str = if content_changed {
+                    diff.to_string()
+                } else {
+                    String::new()
+                };
+                if let Some((old_mode, new_mode)) = r.permission_change {
+                    diff_str.push_str(&format!(
+                        "{}{}\n",
+                        "~ permissions: ".yellow(),
+                        format!("{:04o} → {:04o}", old_mode, new_mode).blue()
+                    ));
+                }
+                files_with_changes.push((target_path, diff_str));
             } else {
                 files_without_changes.push((target_path, diff.to_string()));
             }
@@ -193,22 +225,26 @@ where
                 continue;
             }
 
-            // If the target file exists and there are changes, trash it
-            if use_trash && target_path.is_file() && r.any_changes == Some(true) {
-                if let Err(e) = trash::delete(&target_path) {
-                    return Err(Error::MoveFileToTrash(e));
-                }
-                num_trashed += 1;
-            }
+            let content_changed = r.content_changes == Some(true);
 
-            // Create parent directories and write file
-            if let Some(target_parent) = target_path.parent() {
-                if let Err(e) = fs::create_dir_all(target_parent) {
-                    return Err(Error::FileWrite(target_path, e));
+            if content_changed {
+                // If the target file exists and content changed, trash it
+                if use_trash && target_path.is_file() {
+                    if let Err(e) = trash::delete(&target_path) {
+                        return Err(Error::MoveFileToTrash(e));
+                    }
+                    num_trashed += 1;
                 }
-            }
-            if let Err(e) = fs::write(&target_path, &r.render_str) {
-                return Err(Error::FileWrite(target_path.clone(), e));
+
+                // Create parent directories and write file
+                if let Some(target_parent) = target_path.parent() {
+                    if let Err(e) = fs::create_dir_all(target_parent) {
+                        return Err(Error::FileWrite(target_path, e));
+                    }
+                }
+                if let Err(e) = fs::write(&target_path, &r.render_str) {
+                    return Err(Error::FileWrite(target_path.clone(), e));
+                }
             }
 
             #[cfg(unix)]
@@ -425,6 +461,165 @@ preserve_permissions = true
         let output_path = tmp_dir.get_file_path("output.sh");
         let output_mode = fs::metadata(&output_path).unwrap().permissions().mode();
         assert_eq!(output_mode & 0o7777, template_mode);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_apply_patina_permission_only_change() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp_dir = TmpTestDir::new();
+        let content = "#!/usr/bin/env bash\necho hello\n";
+        let patina_path = tmp_dir.write_file(
+            "perm_only_patina.toml",
+            r#"name = "perm-only"
+description = "Test permission-only change detection"
+
+[[files]]
+template = "script.sh"
+target = "output.sh"
+preserve_permissions = true
+"#,
+        );
+
+        let template_path = tmp_dir.write_file("script.sh", content);
+        fs::set_permissions(&template_path, fs::Permissions::from_mode(0o755)).unwrap();
+
+        // Existing target with same content but different permissions
+        let target_path = tmp_dir.write_file("output.sh", content);
+        fs::set_permissions(&target_path, fs::Permissions::from_mode(0o644)).unwrap();
+
+        let pi = TestPatinaInterface::new();
+        let engine = PatinaEngine::new(&pi, &patina_path, vec![], vec![]);
+        let apply = engine.apply_patina(false);
+        assert!(apply.is_ok());
+
+        let output = pi.get_all_output();
+        assert!(!output.contains("No file changes detected"));
+        assert!(output.contains("~ permissions: 0644 → 0755"));
+        assert!(output.contains("Applying patina files"));
+
+        // Content should be unchanged
+        assert_eq!(fs::read_to_string(&target_path).unwrap(), content);
+        // Permissions should be updated
+        let output_mode = fs::metadata(&target_path).unwrap().permissions().mode();
+        assert_eq!(output_mode & 0o7777, 0o755);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_apply_patina_no_change_when_permissions_match() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp_dir = TmpTestDir::new();
+        let content = "#!/usr/bin/env bash\necho hello\n";
+        let patina_path = tmp_dir.write_file(
+            "perm_match_patina.toml",
+            r#"name = "perm-match"
+description = "Test no change when content and permissions match"
+
+[[files]]
+template = "script.sh"
+target = "output.sh"
+preserve_permissions = true
+"#,
+        );
+
+        let template_path = tmp_dir.write_file("script.sh", content);
+        fs::set_permissions(&template_path, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let target_path = tmp_dir.write_file("output.sh", content);
+        fs::set_permissions(&target_path, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let pi = TestPatinaInterface::new();
+        let engine = PatinaEngine::new(&pi, &patina_path, vec![], vec![]);
+        let apply = engine.apply_patina(false);
+        assert!(apply.is_ok());
+
+        let output = pi.get_all_output();
+        assert!(output.contains("No file changes detected"));
+        assert!(!output.contains("~ permissions:"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_apply_patina_content_and_permission_change() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp_dir = TmpTestDir::new();
+        let patina_path = tmp_dir.write_file(
+            "content_and_perm_patina.toml",
+            r#"name = "content-and-perm"
+description = "Test content and permission change together"
+
+[[files]]
+template = "script.sh"
+target = "output.sh"
+preserve_permissions = true
+"#,
+        );
+
+        let template_path = tmp_dir.write_file("script.sh", "#!/usr/bin/env bash\necho updated\n");
+        fs::set_permissions(&template_path, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let target_path = tmp_dir.write_file("output.sh", "#!/usr/bin/env bash\necho original\n");
+        fs::set_permissions(&target_path, fs::Permissions::from_mode(0o644)).unwrap();
+
+        let pi = TestPatinaInterface::new();
+        let engine = PatinaEngine::new(&pi, &patina_path, vec![], vec![]);
+        let apply = engine.apply_patina(false);
+        assert!(apply.is_ok());
+
+        let output = pi.get_all_output();
+        assert!(!output.contains("No file changes detected"));
+        assert!(output.contains("~ permissions: 0644 → 0755"));
+        assert!(output.contains("echo updated"));
+        assert!(output.contains("Applying patina files"));
+
+        assert_eq!(
+            fs::read_to_string(&target_path).unwrap(),
+            "#!/usr/bin/env bash\necho updated\n"
+        );
+        let output_mode = fs::metadata(&target_path).unwrap().permissions().mode();
+        assert_eq!(output_mode & 0o7777, 0o755);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_apply_patina_permission_difference_ignored_without_preserve() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp_dir = TmpTestDir::new();
+        let content = "#!/usr/bin/env bash\necho hello\n";
+        let patina_path = tmp_dir.write_file(
+            "no_preserve_patina.toml",
+            r#"name = "no-preserve"
+description = "Test that permission differences are ignored without preserve_permissions"
+
+[[files]]
+template = "script.sh"
+target = "output.sh"
+"#,
+        );
+
+        let template_path = tmp_dir.write_file("script.sh", content);
+        fs::set_permissions(&template_path, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let target_path = tmp_dir.write_file("output.sh", content);
+        fs::set_permissions(&target_path, fs::Permissions::from_mode(0o644)).unwrap();
+
+        let pi = TestPatinaInterface::new();
+        let engine = PatinaEngine::new(&pi, &patina_path, vec![], vec![]);
+        let apply = engine.apply_patina(false);
+        assert!(apply.is_ok());
+
+        let output = pi.get_all_output();
+        assert!(output.contains("No file changes detected"));
+        assert!(!output.contains("~ permissions:"));
+
+        // Permissions should remain unchanged since preserve_permissions is false
+        let output_mode = fs::metadata(&target_path).unwrap().permissions().mode();
+        assert_eq!(output_mode & 0o7777, 0o644);
     }
 
     #[test]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -211,6 +211,16 @@ where
                 return Err(Error::FileWrite(target_path.clone(), e));
             }
 
+            #[cfg(unix)]
+            if r.patina_file.preserve_permissions {
+                let template_path = patina.get_patina_path(&r.patina_file.template);
+                let permissions = fs::metadata(&template_path)
+                    .map_err(|e| Error::FileRead(template_path, e))?
+                    .permissions();
+                fs::set_permissions(&target_path, permissions)
+                    .map_err(|e| Error::FileWrite(target_path.clone(), e))?;
+            }
+
             self.pi.output(" ✓\n".green().to_string());
         }
 
@@ -384,6 +394,37 @@ Templates use the Handebars templating language. For more information, see <http
 
         assert!(apply.is_ok());
         assert!(pi.get_all_output().contains("Not applying patina."))
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_apply_patina_preserve_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp_dir = TmpTestDir::new();
+        let patina_path = tmp_dir.write_file(
+            "preserve_perms_patina.toml",
+            r#"name = "preserve-perms"
+description = "Test preserve_permissions"
+
+[[files]]
+template = "script.sh"
+target = "output.sh"
+preserve_permissions = true
+"#,
+        );
+        let template_path = tmp_dir.write_file("script.sh", "#!/usr/bin/env bash\necho hello\n");
+        let template_mode = 0o755;
+        fs::set_permissions(&template_path, fs::Permissions::from_mode(template_mode)).unwrap();
+
+        let pi = TestPatinaInterface::new();
+        let engine = PatinaEngine::new(&pi, &patina_path, vec![], vec![]);
+        let apply = engine.apply_patina(false);
+        assert!(apply.is_ok());
+
+        let output_path = tmp_dir.get_file_path("output.sh");
+        let output_mode = fs::metadata(&output_path).unwrap().permissions().mode();
+        assert_eq!(output_mode & 0o7777, template_mode);
     }
 
     #[test]

--- a/src/patina.rs
+++ b/src/patina.rs
@@ -331,16 +331,19 @@ mod tests {
                     template: PathBuf::from("a.hbs"),
                     target: PathBuf::from("a.txt"),
                     tags: vec!["a".to_string()],
+                    preserve_permissions: false,
                 },
                 PatinaFile {
                     template: PathBuf::from("b.hbs"),
                     target: PathBuf::from("b.txt"),
                     tags: vec!["b".to_string()],
+                    preserve_permissions: false,
                 },
                 PatinaFile {
                     template: PathBuf::from("ab.hbs"),
                     target: PathBuf::from("ab.txt"),
                     tags: vec!["a".to_string(), "b".to_string()],
+                    preserve_permissions: false,
                 },
             ],
         };

--- a/src/patina/patina_file.rs
+++ b/src/patina/patina_file.rs
@@ -16,6 +16,11 @@ pub struct PatinaFile {
 
     /// The path to the garget output file
     pub target: PathBuf,
+
+    /// When true, the template file's permissions are copied to the target file after writing.
+    /// Useful for executable scripts.
+    #[serde(default)]
+    pub preserve_permissions: bool,
 }
 
 #[cfg(test)]
@@ -32,6 +37,7 @@ mod tests {
                 template,
                 target,
                 tags: vec![],
+                preserve_permissions: false,
             }
         }
 

--- a/src/templating.rs
+++ b/src/templating.rs
@@ -17,11 +17,21 @@ pub struct PatinaFileRender<'pf> {
     /// A reference to the [PatinaFile]
     pub patina_file: &'pf PatinaFile,
 
-    /// Whether or not the file has changes.
+    /// Whether or not the file has any changes (content or permissions).
     /// - [None]: if the file has not been diffed with the target yet
     /// - [true]: if the diff detected any changes
     /// - [false]: if the diff did not detect any changes
     pub any_changes: Option<bool>,
+
+    /// Whether or not the file content has changes specifically.
+    /// - [None]: if the file has not been diffed with the target yet
+    /// - [true]: if the content diff detected changes
+    /// - [false]: if the content diff did not detect changes
+    pub content_changes: Option<bool>,
+
+    /// The permission change (old_mode, new_mode) if permissions differ between template and target.
+    /// Always [None] on non-unix platforms or when [PatinaFile::preserve_permissions] is false.
+    pub permission_change: Option<(u32, u32)>,
 
     /// The full render string for this file
     pub render_str: String,
@@ -44,6 +54,8 @@ pub fn render_patina(
                 patina_file: pf,
                 render_str: render,
                 any_changes: None,
+                content_changes: None,
+                permission_change: None,
             })
         })
         .collect()

--- a/src/templating.rs
+++ b/src/templating.rs
@@ -28,7 +28,10 @@ pub struct PatinaFileRender<'pf> {
 }
 
 /// Renders all the [PatinaFile]s in a [Patina].
-pub fn render_patina(patina: &Patina, tags: Option<Vec<String>>) -> Result<Vec<PatinaFileRender>> {
+pub fn render_patina(
+    patina: &Patina,
+    tags: Option<Vec<String>>,
+) -> Result<Vec<PatinaFileRender<'_>>> {
     let mut hb = Handlebars::new();
     hb.register_escape_fn(handlebars::no_escape);
     hb.set_strict_mode(true);


### PR DESCRIPTION
- Adds a `preserve_permissions` field to PatinaFile that, when enabled, copies the template file's Unix permissions to the target after writing — making it easy to manage executable scripts (e.g. `chmod +x`) via dotpatina
- Extends diff analysis to detect permission-only changes: the render/apply preview now shows `~ permissions: 0644 → 0755` when content is identical but modes differ
- Adds an example patina (examples/executable-script/) demonstrating the feature with a shell script template
- Adds a CLAUDE.md with architecture docs and development commands